### PR TITLE
sev-stub: implement sev_es_enabled

### DIFF
--- a/target/i386/sev-stub.c
+++ b/target/i386/sev-stub.c
@@ -49,3 +49,9 @@ SevCapability *sev_get_capabilities(void)
 {
     return NULL;
 }
+
+bool sev_es_enabled(void)
+{
+    return false;
+}
+


### PR DESCRIPTION
Otherwise we can see errors with _linux-user_:
```
target/i386/cpu.o: In function `cpu_x86_cpuid':
target/i386/cpu.c:4636: undefined reference to `sev_es_enabled'
```