### PR TITLE
[RFC] Support Legacy VFIO Passthrough with SNP

### DIFF
--- a/accel/kvm/kvm-all.c
+++ b/accel/kvm/kvm-all.c
@@ -3133,6 +3133,10 @@ next_memory_region:
     addr = memory_region_get_ram_ptr(mr) + section.offset_within_region;
     rb = qemu_ram_block_from_host(addr, false, &offset);
 
+    convert_start = section.offset_within_region;
+    convert_size = (convert_start + size > mr->size) ?
+                   mr->size - convert_start : size;
+
     if (to_private) {
         /*
          * The attributes need to be set to private *after* the notification
@@ -3142,20 +3146,20 @@ next_memory_region:
          * unmappings are done in advance.
          */
         ret = ram_block_attributes_state_change(RAM_BLOCK_ATTRIBUTES(mr->rdm),
-                                                offset, size, to_private);
+                                                offset, convert_size, to_private);
         if (ret) {
             error_report("Failed to notify the listener the state change of "
                          "(0x%"HWADDR_PRIx" + 0x%"HWADDR_PRIx") to %s, ret %d",
-                         start, size, to_private ? "private" : "shared", ret);
+                         start, convert_size, to_private ? "private" : "shared", ret);
             goto out_unref;
         }
 
-        ret = kvm_set_memory_attributes_private(start, size);
+        ret = kvm_set_memory_attributes_private(start, convert_size);
         if (ret) {
             goto out_unref;
         }
     } else {
-        ret = kvm_set_memory_attributes_shared(start, size);
+        ret = kvm_set_memory_attributes_shared(start, convert_size);
         if (ret) {
             goto out_unref;
         }
@@ -3168,18 +3172,14 @@ next_memory_region:
          * attributes set to shared.
          */
         ret = ram_block_attributes_state_change(RAM_BLOCK_ATTRIBUTES(mr->rdm),
-                                                offset, size, to_private);
+                                                offset, convert_size, to_private);
         if (ret) {
             error_report("Failed to notify the listener the state change of "
                          "(0x%"HWADDR_PRIx" + 0x%"HWADDR_PRIx") to %s, ret %d",
-                         start, size, to_private ? "private" : "shared", ret);
+                         start, convert_size, to_private ? "private" : "shared", ret);
             goto out_unref;
         }
     }
-
-    convert_start = section.offset_within_region;
-    convert_size = (convert_start + size > mr->size) ?
-                   mr->size - convert_start : size;
 
     /*
      * Discarding after conversion is generally done to avoid doubling of

--- a/hw/vfio/common.c
+++ b/hw/vfio/common.c
@@ -350,8 +350,8 @@ static void vfio_ram_discard_notify_discard(RamDiscardListener *rdl,
     /* Unmap with a single call. */
     ret = vfio_container_dma_unmap(bcontainer, iova, size , NULL);
     if (ret) {
-        error_report("%s: vfio_container_dma_unmap() failed: %s", __func__,
-                     strerror(-ret));
+        error_report("%s: vfio_container_dma_unmap() failed: %s. iova  = %lx, size = %lx",
+                     __func__, strerror(-ret), iova, size);
     }
 }
 

--- a/hw/vfio/common.c
+++ b/hw/vfio/common.c
@@ -284,7 +284,7 @@ static void vfio_iommu_map_notify(IOMMUNotifier *n, IOMMUTLBEntry *iotlb)
     VFIOContainerBase *bcontainer = giommu->bcontainer;
     hwaddr iova = iotlb->iova + giommu->iommu_offset;
     void *vaddr;
-    int ret, memfd = -1;
+    int ret;
     Error *local_err = NULL;
 
     trace_vfio_iommu_map_notify(iotlb->perm == IOMMU_NONE ? "UNMAP" : "MAP",
@@ -315,7 +315,7 @@ static void vfio_iommu_map_notify(IOMMUNotifier *n, IOMMUTLBEntry *iotlb)
          */
         ret = vfio_container_dma_map(bcontainer, iova,
                                      iotlb->addr_mask + 1, vaddr,
-                                     read_only, memfd);
+                                     read_only, NULL);
         if (ret) {
             error_report("vfio_container_dma_map(%p, 0x%"HWADDR_PRIx", "
                          "0x%"HWADDR_PRIx", %p) = %d (%s)",
@@ -365,7 +365,7 @@ static int vfio_ram_discard_notify_populate(RamDiscardListener *rdl,
                        int128_get64(section->size);
     hwaddr start, next, iova;
     void *vaddr;
-    int ret, memfd = -1;
+    int ret;
 
     /*
      * Map in (aligned within memory region) minimum granularity, so we can
@@ -379,13 +379,9 @@ static int vfio_ram_discard_notify_populate(RamDiscardListener *rdl,
                section->offset_within_address_space;
         vaddr = memory_region_get_ram_ptr(section->mr) + start;
 
-        if (memory_region_has_guest_memfd(section->mr)) {
-            memfd = section->mr->ram_block->guest_memfd;
-            vaddr = (void *) start;
-        }
-
         ret = vfio_container_dma_map(bcontainer, iova, next - start,
-                                     vaddr, section->readonly, memfd);
+                                     vaddr, section->readonly,
+                                     section->mr);
         if (ret) {
             /* Rollback */
             vfio_ram_discard_notify_discard(rdl, section);
@@ -583,7 +579,7 @@ static void vfio_listener_region_add(MemoryListener *listener,
     hwaddr iova, end;
     Int128 llend, llsize;
     void *vaddr;
-    int ret, memfd = -1;
+    int ret;
     Error *err = NULL;
 
     if (!vfio_listener_valid_section(section, "region_add")) {
@@ -682,13 +678,9 @@ static void vfio_listener_region_add(MemoryListener *listener,
         }
     }
 
-    if (memory_region_has_guest_memfd(section->mr)) {
-        memfd = section->mr->ram_block->guest_memfd;
-        vaddr = (void *) section->offset_within_region;
-    }
-
     ret = vfio_container_dma_map(bcontainer, iova, int128_get64(llsize),
-                                 vaddr, section->readonly, memfd);
+                                 vaddr, section->readonly,
+                                 section->mr);
     if (ret) {
         error_setg(&err, "vfio_container_dma_map(%p, 0x%"HWADDR_PRIx", "
                    "0x%"HWADDR_PRIx", %p) = %d (%s)",

--- a/hw/vfio/container-base.c
+++ b/hw/vfio/container-base.c
@@ -17,12 +17,13 @@
 
 int vfio_container_dma_map(VFIOContainerBase *bcontainer,
                            hwaddr iova, ram_addr_t size,
-                           void *vaddr, bool readonly, int memfd)
+                           void *vaddr, bool readonly,
+                           MemoryRegion *mr)
 {
     VFIOIOMMUClass *vioc = VFIO_IOMMU_GET_CLASS(bcontainer);
 
     g_assert(vioc->dma_map);
-    return vioc->dma_map(bcontainer, iova, size, vaddr, readonly, memfd);
+    return vioc->dma_map(bcontainer, iova, size, vaddr, readonly, mr);
 }
 
 int vfio_container_dma_unmap(VFIOContainerBase *bcontainer,

--- a/hw/vfio/container.c
+++ b/hw/vfio/container.c
@@ -175,7 +175,8 @@ static int vfio_legacy_dma_unmap(const VFIOContainerBase *bcontainer,
 }
 
 static int vfio_legacy_dma_map(const VFIOContainerBase *bcontainer, hwaddr iova,
-                               ram_addr_t size, void *vaddr, bool readonly, int memfd)
+                               ram_addr_t size, void *vaddr,
+                               bool readonly, MemoryRegion *mr)
 {
     const VFIOContainer *container = container_of(bcontainer, VFIOContainer,
                                                   bcontainer);

--- a/hw/vfio/iommufd.c
+++ b/hw/vfio/iommufd.c
@@ -27,10 +27,20 @@
 #include "pci.h"
 
 static int iommufd_cdev_map(const VFIOContainerBase *bcontainer, hwaddr iova,
-                            ram_addr_t size, void *vaddr, bool readonly, int memfd)
+                            ram_addr_t size, void *vaddr,
+                            bool readonly, MemoryRegion *mr)
 {
     const VFIOIOMMUFDContainer *container =
         container_of(bcontainer, VFIOIOMMUFDContainer, bcontainer);
+    int memfd = -1;
+
+    if (mr && memory_region_has_guest_memfd(mr)) {
+        ram_addr_t offset = (uint8_t *)vaddr -
+                            (uint8_t *)memory_region_get_ram_ptr(mr);
+
+        memfd = memory_region_get_guest_memfd(mr);
+        vaddr = (void *) offset;
+    }
 
     return iommufd_backend_map_dma(container->be,
                                    container->ioas_id,

--- a/include/exec/memory.h
+++ b/include/exec/memory.h
@@ -245,7 +245,7 @@ typedef struct IOMMUTLBEvent {
 
 /* RAM can be private that has kvm guest memfd backend */
 #define RAM_GUEST_MEMFD   (1 << 12)
-#define RAM_GUEST_MEMFD_NOHUGE   (1 << 13)
+#define RAM_GUEST_MEMFD_NOHUGE   (1 << 14)
 
 /*
  * In RAMBlock creation functions, if MAP_SHARED is 0 in the flags parameter,

--- a/include/exec/memory.h
+++ b/include/exec/memory.h
@@ -1815,6 +1815,15 @@ bool memory_region_is_protected(MemoryRegion *mr);
 bool memory_region_has_guest_memfd(MemoryRegion *mr);
 
 /**
+ * memory_region_get_guest_memfd: get guest_memfd of a memory region
+ *
+ * Returns guest_memfd of a memory region if it has guest_memfd assigned.
+ * Otherwise, -1 is returned.
+ *
+ * @mr: the memory region being queried
+ */
+int memory_region_get_guest_memfd(MemoryRegion *mr);
+/**
  * memory_region_get_iommu: check whether a memory region is an iommu
  *
  * Returns pointer to IOMMUMemoryRegion if a memory region is an iommu,

--- a/include/hw/vfio/vfio-container-base.h
+++ b/include/hw/vfio/vfio-container-base.h
@@ -73,7 +73,8 @@ typedef struct VFIORamDiscardListener {
 
 int vfio_container_dma_map(VFIOContainerBase *bcontainer,
                            hwaddr iova, ram_addr_t size,
-                           void *vaddr, bool readonly, int memfd);
+                           void *vaddr, bool readonly,
+                           MemoryRegion *mr);
 int vfio_container_dma_unmap(VFIOContainerBase *bcontainer,
                              hwaddr iova, ram_addr_t size,
                              IOMMUTLBEntry *iotlb);
@@ -113,7 +114,8 @@ struct VFIOIOMMUClass {
     bool (*setup)(VFIOContainerBase *bcontainer, Error **errp);
     int (*dma_map)(const VFIOContainerBase *bcontainer,
                    hwaddr iova, ram_addr_t size,
-                   void *vaddr, bool readonly, int memfd);
+                   void *vaddr, bool readonly,
+                   MemoryRegion *mr);
     int (*dma_unmap)(const VFIOContainerBase *bcontainer,
                      hwaddr iova, ram_addr_t size,
                      IOMMUTLBEntry *iotlb);

--- a/system/memory.c
+++ b/system/memory.c
@@ -1894,6 +1894,11 @@ bool memory_region_has_guest_memfd_only(MemoryRegion *mr)
            current_machine->cgs->convert_in_place;
 }
 
+int memory_region_get_guest_memfd(MemoryRegion *mr)
+{
+    return memory_region_has_guest_memfd(mr) ? mr->ram_block->guest_memfd : -1;
+}
+
 uint8_t memory_region_get_dirty_log_mask(MemoryRegion *mr)
 {
     uint8_t mask = mr->dirty_log_mask;

--- a/system/physmem.c
+++ b/system/physmem.c
@@ -2059,7 +2059,7 @@ RAMBlock *qemu_ram_alloc_from_fd(ram_addr_t size, ram_addr_t max_size,
     assert((ram_flags & ~(RAM_SHARED | RAM_PMEM | RAM_NORESERVE |
                           RAM_PROTECTED | RAM_NAMED_FILE | RAM_READONLY |
                           RAM_READONLY_FD | RAM_GUEST_MEMFD |
-                          RAM_RESIZEABLE)) == 0);
+                          RAM_RESIZEABLE | RAM_GUEST_MEMFD_NOHUGE)) == 0);
     assert(max_size >= size);
 
     if (xen_enabled()) {
@@ -2241,7 +2241,7 @@ RAMBlock *qemu_ram_alloc_internal(ram_addr_t size, ram_addr_t max_size,
     ram_flags &= ~RAM_PRIVATE;
 
     assert((ram_flags & ~(RAM_SHARED | RAM_RESIZEABLE | RAM_PREALLOC |
-                          RAM_NORESERVE | RAM_GUEST_MEMFD)) == 0);
+                          RAM_NORESERVE | RAM_GUEST_MEMFD | RAM_GUEST_MEMFD_NOHUGE)) == 0);
     assert(!host ^ (ram_flags & RAM_PREALLOC));
     assert(max_size >= size);
 
@@ -2339,7 +2339,7 @@ RAMBlock *qemu_ram_alloc(ram_addr_t size, uint32_t ram_flags,
                          MemoryRegion *mr, Error **errp)
 {
     assert((ram_flags & ~(RAM_SHARED | RAM_NORESERVE | RAM_GUEST_MEMFD |
-                          RAM_PRIVATE)) == 0);
+                          RAM_PRIVATE | RAM_GUEST_MEMFD_NOHUGE)) == 0);
     return qemu_ram_alloc_internal(size, size, NULL, NULL, ram_flags, mr, errp);
 }
 


### PR DESCRIPTION
Hi Michael,

I’m currently testing VFIO passthrough with vfio_iommu_type1 based on the AMD SNP branch. After applying the QEMU patches from this commit, we’re able to launch a passthrough VM using the following command line with vfio_iommu_type1:
```
/usr/bin/qemu-system-x86_64 \
... \
-device '{"driver":"vfio-pci","host":"0000:03:00.0","id":"hostdev0","bus":"pci.0","addr":"0x4"}' \
-object '{"qom-type":"sev-snp-guest","id":"lsec0","cbitpos":51,"reduced-phys-bits":1,"policy":720896,"convert-in-place":true,"gmem-allocator":"hugetlb","gmem-page-size":2097152}'
```

Test branches:
- QEMU: https://github.com/yipengyin/qemu/tree/snp-hugetlb-dev-wip0
- Linux: https://github.com/openvelinux/kernel/tree/ve-snp-hugetlb-v2-wip0 or https://github.com/AMDESE/linux/commits/snp-hugetlb-v2-wip0/

However, during testing we found that QEMU hangs when being killed — the process does not exit. The root cause appears to be a deadlock caused by a circular dependency between VFIO group release and teardown_finalize.

More specifically:

1. vfio_group_unuse_container schedules task_work (func = ____fput) on the QEMU main thread, which requires returning to user space to execute. If the task_work is not run, vfio_group_fops_release will never be called.
``` c
// init_task_work(&file->f_rcuhead, ____fput)
vfio_group_unuse_container+1
vfio_df_close+116
vfio_df_group_close+50
vfio_device_fops_release+32
__fput+236
task_work_run+86
do_exit+847
do_group_exit+45
__x64_sys_exit_group+20
do_syscall_64+52
entry_SYSCALL_64_after_hwframe+104
```

2. During gmem release, execution reaches teardown_finalize, which loops waiting for the hugepage subpool to be released. However, the folios are still pinned by VFIO, causing the kernel to block in teardown_finalize and never return to user space.
```c
// loop in while (private->spool_active) cond_resched();
teardown_finalize
kvm_destroy_vm+0x2a3/0x370 [kvm]
kvm_gmem_release+0x153/0x180 [kvm]
__fput+0xec/0x290
task_work_run+0x56/0x80
do_exit+0x34f/0xaf0
do_group_exit+0x2d/0x80
__x64_sys_exit_group+0x14/0x20
do_syscall_64+0x34/0x80
```

As a result, the process gets stuck in kernel space and cannot complete the exit path.

Could you help confirm this issue and advise on a possible fix?